### PR TITLE
Do not -lpng

### DIFF
--- a/custom_config_utility/Makefile
+++ b/custom_config_utility/Makefile
@@ -14,7 +14,7 @@ DEFS        +=
 CFLAGS       = -std=gnu99 -Wall -Wno-unused-variable -O2 $(DEFS) $(INCLUDE)
 #CFLAGS       = -std=gnu99 -Wall -Wno-unused-variable -O0 -g $(DEFS) $(INCLUDE)
 CFLAGS      += -DGCW
-LDFLAGS     := -L$(SYSROOT)/usr/lib -lSDL -lpthread -lSDL_gfx -lSDL_image -lpng -lz 
+LDFLAGS     := -L$(SYSROOT)/usr/lib -lSDL -lpthread -lSDL_gfx -lSDL_image -lz 
 
 .PHONY: all clean
 


### PR DESCRIPTION
This project uses SDL_Image to load images.

libpng doesn't need to and should not be linked directly in this case, as this causes issues if the libpng version on the device is not the same as in the toolchain. E.g. the original gcw0 toolchain has libpng14 but the upcoming OpenDingux firmware will have the latest libpng.